### PR TITLE
Fix for UTF-8 passwords

### DIFF
--- a/django_bcrypt/models.py
+++ b/django_bcrypt/models.py
@@ -9,7 +9,7 @@ _check_password = User.check_password
 def bcrypt_check_password(self, raw_password):
     if self.password.startswith('bc$'):
         salt_and_hash = self.password[3:]
-        return bcrypt.hashpw(raw_password, salt_and_hash) == salt_and_hash
+        return bcrypt.hashpw(raw_password.encode("utf-8"), salt_and_hash) == salt_and_hash
     return _check_password(self, raw_password)
 
 def bcrypt_set_password(self, raw_password):
@@ -17,7 +17,7 @@ def bcrypt_set_password(self, raw_password):
         self.set_unusable_password()
     else:
         salt = bcrypt.gensalt(rounds)
-        self.password = 'bc$' + bcrypt.hashpw(raw_password, salt)
+        self.password = 'bc$' + bcrypt.hashpw(raw_password.encode("utf-8"), salt)
 
 User.check_password = bcrypt_check_password
 User.set_password = bcrypt_set_password


### PR DESCRIPTION
This is a real simple fix and an issue we had if someone attempted to use a password with a ñ for example.
