### PR TITLE
Unicode password support using Django's unicode handling, including test case

### DIFF
--- a/django_bcrypt/models.py
+++ b/django_bcrypt/models.py
@@ -21,6 +21,7 @@ import bcrypt
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core import mail
+from django.utils.encoding import smart_str
 
 
 def get_rounds():
@@ -48,7 +49,7 @@ def bcrypt_check_password(self, raw_password):
     """
     if self.password.startswith('bc$'):
         salt_and_hash = self.password[3:]
-        return bcrypt.hashpw(raw_password, salt_and_hash) == salt_and_hash
+        return bcrypt.hashpw(smart_str(raw_password), salt_and_hash) == salt_and_hash
     return _check_password(self, raw_password)
 _check_password = User.check_password
 User.check_password = bcrypt_check_password
@@ -62,6 +63,6 @@ def bcrypt_set_password(self, raw_password):
         _set_password(self, raw_password)
     else:
         salt = bcrypt.gensalt(get_rounds())
-        self.password = 'bc$' + bcrypt.hashpw(raw_password, salt)
+        self.password = 'bc$' + bcrypt.hashpw(smart_str(raw_password), salt)
 _set_password = User.set_password
 User.set_password = bcrypt_set_password

--- a/django_bcrypt/tests.py
+++ b/django_bcrypt/tests.py
@@ -21,6 +21,13 @@ class CheckPasswordTest(TestCase):
         self.assertTrue(bcrypt_check_password(user, 'password'))
         self.assertFalse(bcrypt_check_password(user, 'invalid'))
 
+    def test_unicode_password(self):
+        user = User()
+        with settings():
+            bcrypt_set_password(user, u"aáåäeéêëoôö")
+        self.assertTrue(bcrypt_check_password(user, u"aaaaeeeeooo"))
+        self.assertFalse(bcrypt_check_password(user, 'invalid'))
+
     def test_sha1_password(self):
         user = User()
         _set_password(user, 'password')


### PR DESCRIPTION
Proper support for unicode passwords using the same methods django.contrib.auth to handle unicode passwords.
