### PR TITLE
Fix unicode password support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,14 +62,20 @@ Default: ``False`` (to speed up user creation)
 Number of rounds to use for bcrypt hashing.  Increase this as computers get faster.
 
 You can change the number of rounds without breaking already-hashed passwords.  New
-passwords will use the new number of rounds, and old ones will use the old number.
+passwords will use the new number of rounds, and old ones will use the old number,
+unless ``BCRYPT_MIGRATE`` is enabled, in which case old ones will be rehashed during
+login to use the new number of rounds.
+
+The number of rounds bcrypt actually uses is 2^N. So when this is ``12``, bcrypt
+uses 4096 rounds.
 
 Default: ``12``
 
 ``BCRYPT_MIGRATE``
 ``````````````````
 
-Enables bcrypt password migration on a ``check_password()`` call.
+Enables bcrypt password migration on a ``check_password()`` call. Use this to 
+migrate an existing deployment (that's using the default auth) over to bcrypt.
 
 The hash is also migrated when ``BCRYPT_ROUNDS`` changes.
 

--- a/django_bcrypt/models.py
+++ b/django_bcrypt/models.py
@@ -79,7 +79,7 @@ def bcrypt_check_password(self, raw_password):
     if pwd_ok and should_change and is_enabled() and migrate_to_bcrypt():
         self.set_password(raw_password)
         salt_and_hash = self.password[3:]
-        assert bcrypt.hashpw(raw_password, salt_and_hash) == salt_and_hash
+        assert bcrypt.hashpw(smart_str(raw_password), salt_and_hash) == salt_and_hash
         self.save()
 
     return pwd_ok

--- a/django_bcrypt/tests.py
+++ b/django_bcrypt/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import with_statement
 from contextlib import contextmanager
 
@@ -25,7 +26,8 @@ class CheckPasswordTest(TestCase):
         user = User()
         with settings():
             bcrypt_set_password(user, u"aáåäeéêëoôö")
-        self.assertTrue(bcrypt_check_password(user, u"aaaaeeeeooo"))
+        self.assertTrue(bcrypt_check_password(user, u"aáåäeéêëoôö"))
+        self.assertFalse(bcrypt_check_password(user, u"aaaaeeeeooo"))
         self.assertFalse(bcrypt_check_password(user, 'invalid'))
 
     def test_sha1_password(self):


### PR DESCRIPTION
The test was failing because it was incorrect, not because of a bug in the django-bcrypt lib itself. This fixes it (and clarifies the docs a little as a bonus). Thanks!
