### PR TITLE
Running tests results in 3 errors

### DIFF
--- a/django_bcrypt/tests.py
+++ b/django_bcrypt/tests.py
@@ -1,3 +1,5 @@
+#coding=utf8
+
 from __future__ import with_statement
 from contextlib import contextmanager
 
@@ -9,8 +11,11 @@ from django.test import TestCase
 from django.utils.functional import LazyObject
 
 from django_bcrypt.models import (bcrypt_check_password, bcrypt_set_password,
-                                  _check_password, _set_password,
                                   get_rounds, is_enabled, migrate_to_bcrypt)
+try:
+    from django_bcrypt.models import _check_password, _set_password
+except ImportError:
+    pass
 
 
 class CheckPasswordTest(TestCase):


### PR DESCRIPTION
Errors:
- SyntaxError: Non-ASCII character '\xc3' in file /django_bcrypt/tests.py on line 27, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
- ImportError: cannot import name _check_password
- ImportError: cannot import name _set_password

Set encoding an added an exception clause when importing _check_password and _set_password.
